### PR TITLE
feat: diagnosis MVP for weight-loss drop-off prevention

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -293,13 +293,9 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			inputPaths = (
-			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/lib/core/providers/calorie_savings_provider.dart
+++ b/lib/core/providers/calorie_savings_provider.dart
@@ -24,16 +24,12 @@ final monthlyCalorieGoalProvider =
       (ref) => MonthlyCalorieGoalNotifier(),
     );
 
-// Provider for calorie savings data
-final calorieSavingsDataProvider = FutureProvider<List<CalorieSavingsRecord>>((
-  ref,
-) async {
-  // Watch meal records so savings data updates when meals change.
+/// Ordered list of [DailySummary] from onboarding start through today.
+/// Shared by [calorieSavingsDataProvider] and the diagnosis layer.
+final dailySummariesProvider = FutureProvider<List<DailySummary>>((ref) async {
   final mealRecordsAsync = ref.watch(mealRecordsProvider);
   final startDate = ref.watch(onboardingStartDateProvider);
   if (startDate == null) return [];
-
-  // Only proceed if meal records are loaded
   if (!mealRecordsAsync.hasValue) return [];
 
   final service = ref.watch(dailySummaryServiceProvider);
@@ -43,7 +39,6 @@ final calorieSavingsDataProvider = FutureProvider<List<CalorieSavingsRecord>>((
   final summaries = <DailySummary>[];
   var current = DateTime(startDate.year, startDate.month, startDate.day);
 
-  // Collect days that need (re)computation
   final staleDays = <DateTime>[];
 
   while (!current.isAfter(endDate)) {
@@ -52,9 +47,9 @@ final calorieSavingsDataProvider = FutureProvider<List<CalorieSavingsRecord>>((
         current.month == today.month &&
         current.day == today.day;
     if (cached != null && !isToday) {
-      // Verify cached consumed calories still match meal records
       final meals = service.mealRecords.getMealRecordsForDate(current);
-      final currentConsumed = meals.fold<double>(0.0, (sum, m) => sum + m.calories);
+      final currentConsumed =
+          meals.fold<double>(0.0, (sum, m) => sum + m.calories);
       if ((cached.caloriesConsumed - currentConsumed).abs() < 1.0) {
         summaries.add(cached);
       } else {
@@ -66,14 +61,21 @@ final calorieSavingsDataProvider = FutureProvider<List<CalorieSavingsRecord>>((
     current = current.add(const Duration(days: 1));
   }
 
-  // Recompute stale and uncached days
   for (final day in staleDays) {
     final summary = await service.getDailySummary(day, forceRefresh: true);
     summaries.add(summary);
   }
 
-  // Sort by date to ensure correct order
   summaries.sort((a, b) => a.date.compareTo(b.date));
+  return summaries;
+});
+
+// Provider for calorie savings data
+final calorieSavingsDataProvider = FutureProvider<List<CalorieSavingsRecord>>((
+  ref,
+) async {
+  final summariesAsync = await ref.watch(dailySummariesProvider.future);
+  final summaries = summariesAsync;
 
   double runningTotal = 0;
   return summaries.map((summary) {

--- a/lib/core/providers/diagnosis_logic.dart
+++ b/lib/core/providers/diagnosis_logic.dart
@@ -1,0 +1,166 @@
+import '../../utils/weight_loss_calculator.dart';
+
+/// 診断の種別。優先順 (上から先に評価):
+///   tooShort → goalTooSmall → bodyComp → trackingMismatch → onTrack → unknown
+enum DiagnosisKind {
+  tooShort,
+  goalTooSmall,
+  trackingMismatch,
+  bodyComp,
+  onTrack,
+  unknown,
+}
+
+/// 診断ロジックの純粋入力（Provider / Test 共通）。
+class DiagnosisInput {
+  final int periodDays;
+  final double weightKg;
+  final double dailyDeficitGoalKcal;
+  final double averageDailyActualDeficitKcal;
+  final double? startWeightKg;
+  final double? currentWeightKg;
+  final double targetWeeklyPercentLoss;
+  final double? startBodyFatPercent;
+  final double? currentBodyFatPercent;
+
+  const DiagnosisInput({
+    required this.periodDays,
+    required this.weightKg,
+    required this.dailyDeficitGoalKcal,
+    required this.averageDailyActualDeficitKcal,
+    required this.targetWeeklyPercentLoss,
+    this.startWeightKg,
+    this.currentWeightKg,
+    this.startBodyFatPercent,
+    this.currentBodyFatPercent,
+  });
+}
+
+class DiagnosisResult {
+  final DiagnosisKind kind;
+  final double requiredDailyDeficitKcal;
+  final double expectedWeeklyLossKg;
+  final double? actualLossKg;
+  final double? actualPerExpectedRatio;
+  final String headline;
+  final List<String> body;
+
+  const DiagnosisResult({
+    required this.kind,
+    required this.requiredDailyDeficitKcal,
+    required this.expectedWeeklyLossKg,
+    required this.headline,
+    required this.body,
+    this.actualLossKg,
+    this.actualPerExpectedRatio,
+  });
+}
+
+DiagnosisResult runDiagnosis(DiagnosisInput input) {
+  final required = WeightLossCalculator.requiredDailyDeficit(
+    weightKg: input.weightKg,
+    weeklyPercentLoss: input.targetWeeklyPercentLoss,
+  );
+  final expectedWeeklyKg = input.weightKg * input.targetWeeklyPercentLoss;
+
+  // Actual observed weight loss (positive = loss).
+  double? actualLossKg;
+  if (input.startWeightKg != null && input.currentWeightKg != null) {
+    actualLossKg = input.startWeightKg! - input.currentWeightKg!;
+  }
+
+  final expectedLossKg = WeightLossCalculator.expectedWeightLossKg(
+    cumulativeDeficitKcal:
+        input.averageDailyActualDeficitKcal * input.periodDays,
+  );
+  final ratio = (actualLossKg != null && expectedLossKg > 0.01)
+      ? actualLossKg / expectedLossKg
+      : null;
+
+  DiagnosisKind kind;
+  String headline;
+  List<String> body;
+
+  if (input.periodDays < 7) {
+    kind = DiagnosisKind.tooShort;
+    final daysLeft = 7 - input.periodDays;
+    headline = '記録はまだ $daysLeft 日分足りません';
+    body = [
+      '体重は水分・グリコーゲンで ±1kg ほど揺れます。',
+      'あと $daysLeft 日記録を続けると、傾向が見え始めます。',
+    ];
+  } else if (input.dailyDeficitGoalKcal + 1 < required) {
+    kind = DiagnosisKind.goalTooSmall;
+    final weeklyAtCurrent = input.dailyDeficitGoalKcal *
+        7 /
+        WeightLossCalculator.kcalPerKg;
+    headline = '今の目標では週 -${weeklyAtCurrent.toStringAsFixed(2)}kg ペース';
+    body = [
+      '希望ペースは週 -${expectedWeeklyKg.toStringAsFixed(2)}kg（体重の'
+          ' ${(input.targetWeeklyPercentLoss * 100).toStringAsFixed(1)}%）。',
+      'これには日次赤字 ${required.round()} kcal/日 が必要です。',
+      '今の設定 (${input.dailyDeficitGoalKcal.round()} kcal/日) では'
+          '日々の体重揺れ (±1-2kg) に埋もれて傾向が見えにくくなります。',
+      '目標を引き上げるか、希望ペースを緩めますか？',
+    ];
+  } else if (_isBodyCompWin(input)) {
+    kind = DiagnosisKind.bodyComp;
+    final bfDrop =
+        (input.startBodyFatPercent! - input.currentBodyFatPercent!).abs();
+    headline = '体重キープでも体脂肪は -${bfDrop.toStringAsFixed(1)}%';
+    body = [
+      '体重が減っていなくても、体脂肪率は下がっています。',
+      '筋肉が増えている可能性が高く、「成功」と見て良い状態です。',
+      '体組成計の数値もあわせて見守りましょう。',
+    ];
+  } else if (ratio != null && ratio < 0.5 && input.periodDays >= 14) {
+    kind = DiagnosisKind.trackingMismatch;
+    headline = '理論値より体重が減っていません';
+    body = [
+      '目標赤字は足りています（${required.round()} kcal/日 以上）。',
+      'にも関わらず実測が期待の ${(ratio * 100).round()}% に留まっています。',
+      '以下のどれかが起きているかも:',
+      '・目分量で記録していて、実際は多めに摂取している',
+      '・油・調味料・飲料（ラテ/ジュース/酒）の記録漏れ',
+      '・試食・一口・摘みの記録漏れ',
+      '・外食のカロリー（家庭の 1.5〜2 倍の油）',
+      '・TDEE推定が高すぎる（活動量係数を下げる）',
+    ];
+  } else if (ratio != null && ratio >= 0.8) {
+    kind = DiagnosisKind.onTrack;
+    headline = '順調です';
+    body = [
+      '期待 -${expectedLossKg.toStringAsFixed(1)}kg / 実測 '
+          '-${actualLossKg!.toStringAsFixed(1)}kg。',
+      'このペースを続けましょう。',
+    ];
+  } else {
+    kind = DiagnosisKind.unknown;
+    headline = 'もう少し記録を続けましょう';
+    body = [
+      '判断に足るデータがまだ揃っていません。',
+      '体重・食事の記録を続けてください。',
+    ];
+  }
+
+  return DiagnosisResult(
+    kind: kind,
+    requiredDailyDeficitKcal: required,
+    expectedWeeklyLossKg: expectedWeeklyKg,
+    actualLossKg: actualLossKg,
+    actualPerExpectedRatio: ratio,
+    headline: headline,
+    body: body,
+  );
+}
+
+bool _isBodyCompWin(DiagnosisInput input) {
+  final bf0 = input.startBodyFatPercent;
+  final bf1 = input.currentBodyFatPercent;
+  final w0 = input.startWeightKg;
+  final w1 = input.currentWeightKg;
+  if (bf0 == null || bf1 == null || w0 == null || w1 == null) return false;
+  final weightChangedUpOrFlat = w1 >= w0 - 0.2;
+  final bodyFatDropped = bf1 < bf0 - 0.5;
+  return weightChangedUpOrFlat && bodyFatDropped;
+}

--- a/lib/core/providers/diagnosis_provider.dart
+++ b/lib/core/providers/diagnosis_provider.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../features/progress/providers/pfc_balance_provider.dart';
+import 'calorie_savings_provider.dart';
+import 'diagnosis_logic.dart';
+
+/// Final diagnosis for the current user state. Null if no data yet.
+final diagnosisProvider = Provider<DiagnosisResult?>((ref) {
+  final summariesAsync = ref.watch(dailySummariesProvider);
+  final goals = ref.watch(userGoalsProvider);
+
+  return summariesAsync.maybeWhen(
+    data: (summaries) {
+      if (summaries.isEmpty) return null;
+      final weightKg = goals.bodyWeightKg;
+      if (weightKg == null) return null;
+
+      final periodDays = summaries.length;
+      final totalDailyDeficit = summaries.fold<double>(
+        0,
+        (sum, s) => sum + (s.caloriesBurned - s.caloriesConsumed),
+      );
+      final avgDaily = periodDays == 0 ? 0.0 : totalDailyDeficit / periodDays;
+
+      final weighted = summaries.where((s) => s.weight != null).toList();
+      final double? startWeight =
+          weighted.isNotEmpty ? weighted.first.weight : null;
+      final double? currentWeight =
+          weighted.isNotEmpty ? weighted.last.weight : null;
+      final withBf =
+          summaries.where((s) => s.bodyFatPercentage != null).toList();
+      final double? startBf =
+          withBf.isNotEmpty ? withBf.first.bodyFatPercentage : null;
+      final double? currentBf =
+          withBf.isNotEmpty ? withBf.last.bodyFatPercentage : null;
+
+      final input = DiagnosisInput(
+        periodDays: periodDays,
+        weightKg: weightKg,
+        dailyDeficitGoalKcal: goals.dailyDeficitGoalKcal,
+        averageDailyActualDeficitKcal: avgDaily,
+        targetWeeklyPercentLoss: goals.targetWeeklyPercentLoss,
+        startWeightKg: startWeight,
+        currentWeightKg: currentWeight,
+        startBodyFatPercent: startBf,
+        currentBodyFatPercent: currentBf,
+      );
+      return runDiagnosis(input);
+    },
+    orElse: () => null,
+  );
+});

--- a/lib/features/home/screens/home_screen.dart
+++ b/lib/features/home/screens/home_screen.dart
@@ -12,6 +12,7 @@ import '../../../widgets/todays_meal_records_list.dart';
 import '../../../widgets/ai_advice_card_compact.dart';
 import '../../../routes/router.dart';
 import '../../../design_system/organisms/pfc_dashboard_card.dart';
+import '../widgets/diagnosis_card.dart';
 
 /// Main home screen matching .pen HomeScreen design
 class HomeScreen extends ConsumerWidget {
@@ -106,6 +107,10 @@ class HomeScreen extends ConsumerWidget {
 
               // CalorieSavingsHero
               const HeroPiggyBankDisplay(),
+              const SizedBox(height: 20),
+
+              // Diagnosis (離脱防止のための診断カード)
+              const DiagnosisCard(),
               const SizedBox(height: 20),
 
               // Summary section

--- a/lib/features/home/widgets/diagnosis_card.dart
+++ b/lib/features/home/widgets/diagnosis_card.dart
@@ -1,0 +1,155 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../../core/providers/diagnosis_logic.dart';
+import '../../../core/providers/diagnosis_provider.dart';
+import '../../../design_system/atoms/tonton_card_base.dart';
+import '../../../routes/router.dart';
+import '../../../theme/app_theme.dart' as app_theme;
+import '../../../theme/colors.dart';
+
+/// Home-screen card that surfaces the top diagnosis for the user's
+/// current state (e.g. "目標が小さすぎます", "記録と実態がずれている可能性").
+class DiagnosisCard extends ConsumerWidget {
+  const DiagnosisCard({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final result = ref.watch(diagnosisProvider);
+    if (result == null) return const SizedBox.shrink();
+    if (result.kind == DiagnosisKind.unknown) return const SizedBox.shrink();
+
+    final palette = _paletteFor(result.kind);
+
+    return TontonCardBase(
+      backgroundColor: palette.background,
+      borderColor: palette.border,
+      borderWidth: 1,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(palette.icon, color: palette.accent, size: 22),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  result.headline,
+                  style: TextStyle(
+                    color: app_theme.TontonColors.textPrimary,
+                    fontSize: 16,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          ...result.body.map(
+            (line) => Padding(
+              padding: const EdgeInsets.only(bottom: 4),
+              child: Text(
+                line,
+                style: TextStyle(
+                  color: app_theme.TontonColors.textSecondary,
+                  fontSize: 13,
+                  height: 1.45,
+                ),
+              ),
+            ),
+          ),
+          if (_showCta(result.kind)) ...[
+            const SizedBox(height: 12),
+            Align(
+              alignment: Alignment.centerRight,
+              child: TextButton(
+                onPressed: () => context.push(TontonRoutes.profile),
+                style: TextButton.styleFrom(
+                  foregroundColor: palette.accent,
+                ),
+                child: Text(_ctaLabelFor(result.kind)),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  bool _showCta(DiagnosisKind kind) {
+    return kind == DiagnosisKind.goalTooSmall ||
+        kind == DiagnosisKind.trackingMismatch;
+  }
+
+  String _ctaLabelFor(DiagnosisKind kind) {
+    switch (kind) {
+      case DiagnosisKind.goalTooSmall:
+        return '目標ペースを見直す →';
+      case DiagnosisKind.trackingMismatch:
+        return '設定を確認する →';
+      default:
+        return '設定 →';
+    }
+  }
+
+  _Palette _paletteFor(DiagnosisKind kind) {
+    switch (kind) {
+      case DiagnosisKind.goalTooSmall:
+        return _Palette(
+          icon: Icons.tune_rounded,
+          accent: TontonColors.pigPink,
+          background: const Color(0xFFFFF4F5),
+          border: const Color(0xFFFBC6CC),
+        );
+      case DiagnosisKind.trackingMismatch:
+        return _Palette(
+          icon: Icons.troubleshoot_rounded,
+          accent: const Color(0xFFB8651B),
+          background: const Color(0xFFFFF7E8),
+          border: const Color(0xFFF4D3A1),
+        );
+      case DiagnosisKind.tooShort:
+        return _Palette(
+          icon: Icons.hourglass_bottom_rounded,
+          accent: const Color(0xFF3D6BB0),
+          background: const Color(0xFFEEF4FC),
+          border: const Color(0xFFBFD4EE),
+        );
+      case DiagnosisKind.bodyComp:
+        return _Palette(
+          icon: Icons.fitness_center_rounded,
+          accent: const Color(0xFF1F7A5A),
+          background: const Color(0xFFE8F5EE),
+          border: const Color(0xFFB0DDC3),
+        );
+      case DiagnosisKind.onTrack:
+        return _Palette(
+          icon: Icons.check_circle_rounded,
+          accent: const Color(0xFF1F7A5A),
+          background: const Color(0xFFE8F5EE),
+          border: const Color(0xFFB0DDC3),
+        );
+      case DiagnosisKind.unknown:
+        return _Palette(
+          icon: Icons.help_outline_rounded,
+          accent: app_theme.TontonColors.textSecondary,
+          background: Colors.white,
+          border: const Color(0xFFEAEAEA),
+        );
+    }
+  }
+}
+
+class _Palette {
+  final IconData icon;
+  final Color accent;
+  final Color background;
+  final Color border;
+  _Palette({
+    required this.icon,
+    required this.accent,
+    required this.background,
+    required this.border,
+  });
+}

--- a/lib/features/profile/screens/profile_screen.dart
+++ b/lib/features/profile/screens/profile_screen.dart
@@ -16,6 +16,7 @@ import '../../../theme/app_theme.dart';
 import '../../progress/providers/auto_pfc_provider.dart';
 import '../../../routes/router.dart';
 import '../../../core/providers/auth_provider.dart';
+import '../widgets/pace_selector_card.dart';
 
 class ProfileScreen extends ConsumerStatefulWidget {
   const ProfileScreen({super.key});
@@ -478,6 +479,10 @@ class _ProfileScreenState extends ConsumerState<ProfileScreen> {
                 ],
               ),
             ),
+            const SizedBox(height: Spacing.lg),
+
+            // 減量ペース設定カード
+            const PaceSelectorCard(),
             const SizedBox(height: Spacing.lg),
 
             // 栄養バランスカード

--- a/lib/features/profile/widgets/pace_selector_card.dart
+++ b/lib/features/profile/widgets/pace_selector_card.dart
@@ -1,0 +1,156 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../design_system/atoms/tonton_card_base.dart';
+import '../../../theme/tokens.dart';
+import '../../../utils/weight_loss_calculator.dart';
+import '../../progress/providers/pfc_balance_provider.dart';
+
+/// 減量ペース (0.5% / 0.7% / 1.0% per week) を選んで、必要な日次赤字を
+/// 自動的に目標へ反映させるカード。
+class PaceSelectorCard extends ConsumerWidget {
+  const PaceSelectorCard({super.key});
+
+  static const _presets = [
+    (label: 'ゆるめ', percent: 0.005),
+    (label: '標準', percent: 0.007),
+    (label: '攻め', percent: 0.010),
+  ];
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final goals = ref.watch(userGoalsProvider);
+    final weight = goals.bodyWeightKg;
+    final selected = goals.targetWeeklyPercentLoss;
+
+    return TontonCardBase(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('減量ペース', style: Theme.of(context).textTheme.titleMedium),
+          const SizedBox(height: 4),
+          Text(
+            '健康的な範囲は体重の 0.5〜1.0% / 週。プリセットを選ぶと、'
+            '必要な日次カロリー赤字が自動で設定されます。',
+            style: Theme.of(context).textTheme.bodySmall,
+          ),
+          const SizedBox(height: Spacing.md),
+          SegmentedButton<double>(
+            segments: _presets
+                .map(
+                  (p) => ButtonSegment<double>(
+                    value: p.percent,
+                    label: Text(
+                      '${p.label}\n${(p.percent * 100).toStringAsFixed(1)}%/週',
+                      textAlign: TextAlign.center,
+                    ),
+                  ),
+                )
+                .toList(),
+            selected: {_closest(selected)},
+            onSelectionChanged: (Set<double> v) {
+              ref
+                  .read(userGoalsProvider.notifier)
+                  .applyPacePreset(v.first);
+            },
+          ),
+          const SizedBox(height: Spacing.md),
+          if (weight == null)
+            Text(
+              '体重を設定すると、必要な日次赤字が計算されます。',
+              style: Theme.of(context).textTheme.bodySmall,
+            )
+          else
+            _SummaryRow(
+              weeklyKg: weight * selected,
+              dailyKcal: WeightLossCalculator.requiredDailyDeficit(
+                weightKg: weight,
+                weeklyPercentLoss: selected,
+              ),
+              currentGoal: goals.dailyDeficitGoalKcal,
+            ),
+        ],
+      ),
+    );
+  }
+
+  double _closest(double value) {
+    return _presets
+        .map((p) => p.percent)
+        .reduce((a, b) => (a - value).abs() < (b - value).abs() ? a : b);
+  }
+}
+
+class _SummaryRow extends StatelessWidget {
+  final double weeklyKg;
+  final double dailyKcal;
+  final double currentGoal;
+
+  const _SummaryRow({
+    required this.weeklyKg,
+    required this.dailyKcal,
+    required this.currentGoal,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final mismatch = (currentGoal - dailyKcal).abs() > 1.0;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            _InlineMetric(
+              label: '週あたり',
+              value: '-${weeklyKg.toStringAsFixed(2)} kg',
+            ),
+            const SizedBox(width: 24),
+            _InlineMetric(
+              label: '必要な日次赤字',
+              value: '${dailyKcal.round()} kcal',
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        Text(
+          '現在の目標: ${currentGoal.round()} kcal/日'
+          '${mismatch ? "（未反映）" : ""}',
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: mismatch
+                ? theme.colorScheme.error
+                : theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _InlineMetric extends StatelessWidget {
+  final String label;
+  final String value;
+
+  const _InlineMetric({required this.label, required this.value});
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          label,
+          style: Theme.of(context).textTheme.labelSmall,
+        ),
+        const SizedBox(height: 2),
+        Text(
+          value,
+          style: Theme.of(context)
+              .textTheme
+              .titleMedium
+              ?.copyWith(fontWeight: FontWeight.bold),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/features/progress/providers/pfc_balance_provider.dart
+++ b/lib/features/progress/providers/pfc_balance_provider.dart
@@ -34,13 +34,51 @@ class UserGoalsNotifier extends StateNotifier<UserGoals> {
   }
 
   Future<void> setPfcRatio(PfcRatio ratio) async {
-    state = UserGoals(pfcRatio: ratio, bodyWeightKg: state.bodyWeightKg);
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setString('user_goals', jsonEncode(state.toJson()));
+    state = state.copyWith(pfcRatio: ratio);
+    await _persist();
   }
 
   Future<void> setBodyWeight(double weight) async {
-    state = UserGoals(pfcRatio: state.pfcRatio, bodyWeightKg: weight);
+    state = state.copyWith(bodyWeightKg: weight);
+    await _persist();
+  }
+
+  Future<void> setTargetWeeklyPercentLoss(double percent) async {
+    state = state.copyWith(targetWeeklyPercentLoss: percent);
+    await _persist();
+  }
+
+  /// Convenience: pick a pace and auto-align the current daily deficit goal to it.
+  Future<void> applyPacePreset(double percent) async {
+    final newState = state.copyWith(targetWeeklyPercentLoss: percent);
+    final required = newState.requiredDailyDeficitKcal;
+    state = required != null
+        ? newState.copyWith(dailyDeficitGoalKcal: required.roundToDouble())
+        : newState;
+    await _persist();
+  }
+
+  Future<void> setDailyDeficitGoalKcal(double kcal) async {
+    state = state.copyWith(dailyDeficitGoalKcal: kcal);
+    await _persist();
+  }
+
+  Future<void> setBodyProfile({
+    double? heightCm,
+    int? age,
+    bool? isMale,
+    double? activityFactor,
+  }) async {
+    state = state.copyWith(
+      heightCm: heightCm,
+      age: age,
+      isMale: isMale,
+      activityFactor: activityFactor,
+    );
+    await _persist();
+  }
+
+  Future<void> _persist() async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString('user_goals', jsonEncode(state.toJson()));
   }

--- a/lib/features/savings/screens/savings_screen.dart
+++ b/lib/features/savings/screens/savings_screen.dart
@@ -10,8 +10,8 @@ import '../../../design_system/organisms/hero_piggy_bank_display.dart';
 import '../../../design_system/atoms/tonton_button.dart';
 import '../../../widgets/calorie_weight_chart.dart';
 import '../../../widgets/daily_history_list.dart';
+import '../widgets/expected_vs_actual_card.dart';
 import '../../../routes/router.dart';
-import '../../../theme/colors.dart';
 import '../../../utils/icon_mapper.dart';
 
 /// 貯金タブのメイン画面
@@ -84,6 +84,10 @@ class SavingsScreen extends ConsumerWidget {
                       weeklyAvg: weeklyAvg,
                       periodText: periodText,
                     ),
+                    const SizedBox(height: 20),
+
+                    // 理論値 vs 実測
+                    const ExpectedVsActualCard(),
                     const SizedBox(height: 20),
 
                     // 期間セレクター

--- a/lib/features/savings/widgets/expected_vs_actual_card.dart
+++ b/lib/features/savings/widgets/expected_vs_actual_card.dart
@@ -1,0 +1,133 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../core/providers/calorie_savings_provider.dart';
+import '../../../core/providers/diagnosis_provider.dart';
+import '../../../utils/weight_loss_calculator.dart';
+
+/// 期待減量 vs 実測減量 を並べる軽量カード。
+class ExpectedVsActualCard extends ConsumerWidget {
+  const ExpectedVsActualCard({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final summariesAsync = ref.watch(dailySummariesProvider);
+    final diagnosis = ref.watch(diagnosisProvider);
+
+    return summariesAsync.maybeWhen(
+      data: (summaries) {
+        if (summaries.isEmpty) return const SizedBox.shrink();
+        final cumulativeDeficit = summaries.fold<double>(
+          0,
+          (sum, s) => sum + (s.caloriesBurned - s.caloriesConsumed),
+        );
+        final expectedKg = WeightLossCalculator.expectedWeightLossKg(
+          cumulativeDeficitKcal: cumulativeDeficit,
+        );
+        final actualKg = diagnosis?.actualLossKg;
+
+        return Container(
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: Colors.white,
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(
+              color: Theme.of(context)
+                  .colorScheme
+                  .outline
+                  .withValues(alpha: 0.2),
+            ),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                '理論値と実測',
+                style: Theme.of(context)
+                    .textTheme
+                    .titleMedium
+                    ?.copyWith(fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  _Metric(
+                    label: '期待',
+                    value: '-${expectedKg.toStringAsFixed(1)} kg',
+                    caption: '累積赤字 ÷ 7700',
+                  ),
+                  const SizedBox(width: 24),
+                  _Metric(
+                    label: '実測',
+                    value: actualKg == null
+                        ? '—'
+                        : '${actualKg >= 0 ? "-" : "+"}${actualKg.abs().toStringAsFixed(1)} kg',
+                    caption: '期間初日 → 当日',
+                  ),
+                ],
+              ),
+              if (diagnosis?.actualPerExpectedRatio != null) ...[
+                const SizedBox(height: 8),
+                Text(
+                  '達成率: ${(diagnosis!.actualPerExpectedRatio! * 100).round()}%',
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+              ],
+            ],
+          ),
+        );
+      },
+      orElse: () => const SizedBox.shrink(),
+    );
+  }
+}
+
+class _Metric extends StatelessWidget {
+  final String label;
+  final String value;
+  final String caption;
+
+  const _Metric({
+    required this.label,
+    required this.value,
+    required this.caption,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Expanded(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            label,
+            style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                  color: Theme.of(context)
+                      .colorScheme
+                      .onSurface
+                      .withValues(alpha: 0.6),
+                ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            value,
+            style: Theme.of(context)
+                .textTheme
+                .headlineSmall
+                ?.copyWith(fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 2),
+          Text(
+            caption,
+            style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                  color: Theme.of(context)
+                      .colorScheme
+                      .onSurface
+                      .withValues(alpha: 0.5),
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/models/user_goals.dart
+++ b/lib/models/user_goals.dart
@@ -1,3 +1,4 @@
+import '../utils/weight_loss_calculator.dart';
 import 'pfc_breakdown.dart';
 
 /// Stores user nutrition goals such as PFC balance and protein target.
@@ -15,11 +16,75 @@ class UserGoals {
   /// Current body weight in kilograms for calculating protein goal.
   final double? bodyWeightKg;
 
-  const UserGoals({this.pfcRatio = defaultPfcRatio, this.bodyWeightKg});
+  /// Height in centimeters (used for TDEE estimation).
+  final double? heightCm;
+
+  /// Age in years (used for TDEE estimation).
+  final int? age;
+
+  /// True if male; false if female. Null if unset.
+  final bool? isMale;
+
+  /// Activity factor for TDEE. 1.2=座りがち / 1.375=軽い運動 / 1.55=中 / 1.725=激しい
+  final double activityFactor;
+
+  /// Target weekly weight-loss pace as fraction of body weight.
+  /// 0.005 = 0.5%/週 (ゆるめ), 0.007 = 0.7%/週 (標準), 0.010 = 1.0%/週 (攻め)
+  final double targetWeeklyPercentLoss;
+
+  /// User's currently configured daily calorie deficit goal (kcal/day).
+  /// Legacy default 240 matches the pre-pace app behavior.
+  /// Tapping a pace preset in Profile updates this to match the required deficit.
+  final double dailyDeficitGoalKcal;
+
+  /// Legacy default goal that matches the pre-pace experience.
+  static const double legacyDailyDeficitGoalKcal = 240;
+
+  const UserGoals({
+    this.pfcRatio = defaultPfcRatio,
+    this.bodyWeightKg,
+    this.heightCm,
+    this.age,
+    this.isMale,
+    this.activityFactor = 1.4,
+    this.targetWeeklyPercentLoss =
+        WeightLossCalculator.defaultWeeklyPercent,
+    this.dailyDeficitGoalKcal = legacyDailyDeficitGoalKcal,
+  });
+
+  UserGoals copyWith({
+    PfcRatio? pfcRatio,
+    double? bodyWeightKg,
+    double? heightCm,
+    int? age,
+    bool? isMale,
+    double? activityFactor,
+    double? targetWeeklyPercentLoss,
+    double? dailyDeficitGoalKcal,
+  }) {
+    return UserGoals(
+      pfcRatio: pfcRatio ?? this.pfcRatio,
+      bodyWeightKg: bodyWeightKg ?? this.bodyWeightKg,
+      heightCm: heightCm ?? this.heightCm,
+      age: age ?? this.age,
+      isMale: isMale ?? this.isMale,
+      activityFactor: activityFactor ?? this.activityFactor,
+      targetWeeklyPercentLoss:
+          targetWeeklyPercentLoss ?? this.targetWeeklyPercentLoss,
+      dailyDeficitGoalKcal:
+          dailyDeficitGoalKcal ?? this.dailyDeficitGoalKcal,
+    );
+  }
 
   Map<String, dynamic> toJson() => {
     'pfcRatio': pfcRatio.toJson(),
     'bodyWeightKg': bodyWeightKg,
+    'heightCm': heightCm,
+    'age': age,
+    'isMale': isMale,
+    'activityFactor': activityFactor,
+    'targetWeeklyPercentLoss': targetWeeklyPercentLoss,
+    'dailyDeficitGoalKcal': dailyDeficitGoalKcal,
   };
 
   factory UserGoals.fromJson(Map<String, dynamic> json) {
@@ -29,10 +94,47 @@ class UserGoals {
               ? PfcRatio.fromJson(json['pfcRatio'] as Map<String, dynamic>)
               : defaultPfcRatio,
       bodyWeightKg: (json['bodyWeightKg'] as num?)?.toDouble(),
+      heightCm: (json['heightCm'] as num?)?.toDouble(),
+      age: (json['age'] as num?)?.toInt(),
+      isMale: json['isMale'] as bool?,
+      activityFactor: (json['activityFactor'] as num?)?.toDouble() ?? 1.4,
+      targetWeeklyPercentLoss:
+          (json['targetWeeklyPercentLoss'] as num?)?.toDouble() ??
+              WeightLossCalculator.defaultWeeklyPercent,
+      dailyDeficitGoalKcal:
+          (json['dailyDeficitGoalKcal'] as num?)?.toDouble() ??
+              legacyDailyDeficitGoalKcal,
     );
   }
 
   /// Daily protein goal in grams based on [bodyWeightKg].
   double? get proteinGoalGrams =>
       bodyWeightKg != null ? bodyWeightKg! * 2.0 : null;
+
+  /// Required daily kcal deficit to hit [targetWeeklyPercentLoss].
+  /// Returns null if body weight is unset.
+  double? get requiredDailyDeficitKcal {
+    if (bodyWeightKg == null) return null;
+    return WeightLossCalculator.requiredDailyDeficit(
+      weightKg: bodyWeightKg!,
+      weeklyPercentLoss: targetWeeklyPercentLoss,
+    );
+  }
+
+  /// Estimated TDEE (kcal/day). Returns null if height/age/sex are unset.
+  double? get estimatedTdee {
+    if (bodyWeightKg == null ||
+        heightCm == null ||
+        age == null ||
+        isMale == null) {
+      return null;
+    }
+    return WeightLossCalculator.estimateTdee(
+      weightKg: bodyWeightKg!,
+      heightCm: heightCm!,
+      age: age!,
+      isMale: isMale!,
+      activityFactor: activityFactor,
+    );
+  }
 }

--- a/lib/utils/weight_loss_calculator.dart
+++ b/lib/utils/weight_loss_calculator.dart
@@ -1,0 +1,44 @@
+/// 体重減量の健康的なペース・必要カロリー赤字・期待減量を算出するヘルパー。
+///
+/// 係数の根拠:
+/// - Mifflin-St Jeor 式 (1990): 基礎代謝(BMR)推定
+/// - 1kg の体脂肪 ≈ 7700kcal (日本語圏の一般係数。米国 3500 は pound 基準)
+/// - 健康的な減量ペース: 体重の 0.5〜1.0% / 週 (各種ガイドライン)
+class WeightLossCalculator {
+  static const double kcalPerKg = 7700;
+
+  static const double minHealthyWeeklyPercent = 0.005;
+  static const double maxHealthyWeeklyPercent = 0.010;
+  static const double defaultWeeklyPercent = 0.007;
+
+  /// Mifflin-St Jeor 式で TDEE を推定する。
+  /// 活動係数: 1.2 座りがち / 1.375 軽い運動 / 1.55 中程度 / 1.725 激しい
+  static double estimateTdee({
+    required double weightKg,
+    required double heightCm,
+    required int age,
+    required bool isMale,
+    double activityFactor = 1.4,
+  }) {
+    final bmr =
+        10 * weightKg + 6.25 * heightCm - 5 * age + (isMale ? 5 : -161);
+    return bmr * activityFactor;
+  }
+
+  /// 希望ペース（体重%/週）を達成するために必要な日次カロリー赤字。
+  static double requiredDailyDeficit({
+    required double weightKg,
+    required double weeklyPercentLoss,
+  }) {
+    final weeklyKg = weightKg * weeklyPercentLoss;
+    final weeklyKcal = weeklyKg * kcalPerKg;
+    return weeklyKcal / 7;
+  }
+
+  /// 累積赤字から期待される体重減少量（kg）。
+  static double expectedWeightLossKg({
+    required double cumulativeDeficitKcal,
+  }) {
+    return cumulativeDeficitKcal / kcalPerKg;
+  }
+}

--- a/test/core/providers/diagnosis_logic_test.dart
+++ b/test/core/providers/diagnosis_logic_test.dart
@@ -1,0 +1,99 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tonton/core/providers/diagnosis_logic.dart';
+
+void main() {
+  DiagnosisInput baseInput({
+    int days = 30,
+    double weightKg = 70,
+    double dailyDeficitGoalKcal = 540,
+    double avgDailyActualDeficit = 540,
+    double startWeight = 70,
+    double currentWeight = 69.5,
+    double targetWeeklyPercentLoss = 0.007,
+    double? startBodyFat,
+    double? currentBodyFat,
+  }) {
+    return DiagnosisInput(
+      periodDays: days,
+      weightKg: weightKg,
+      dailyDeficitGoalKcal: dailyDeficitGoalKcal,
+      averageDailyActualDeficitKcal: avgDailyActualDeficit,
+      startWeightKg: startWeight,
+      currentWeightKg: currentWeight,
+      targetWeeklyPercentLoss: targetWeeklyPercentLoss,
+      startBodyFatPercent: startBodyFat,
+      currentBodyFatPercent: currentBodyFat,
+    );
+  }
+
+  test('period < 7 days -> tooShort', () {
+    final r = runDiagnosis(baseInput(days: 5));
+    expect(r.kind, DiagnosisKind.tooShort);
+  });
+
+  test('goal deficit smaller than required -> goalTooSmall', () {
+    // 70kg * 0.007/week needs ~540 kcal/day; user set only 240
+    final r = runDiagnosis(
+      baseInput(days: 30, dailyDeficitGoalKcal: 240),
+    );
+    expect(r.kind, DiagnosisKind.goalTooSmall);
+    expect(r.requiredDailyDeficitKcal, closeTo(539, 1));
+  });
+
+  test('goal ok but actual way below expected (>=14d) -> trackingMismatch', () {
+    // Required ~540/day, goal 540, actual reported 540, but weight barely moved
+    // Expected loss: 540 * 30 / 7700 ≈ 2.1 kg. Actual loss: 0.2 kg -> 10%.
+    final r = runDiagnosis(
+      baseInput(
+        days: 30,
+        dailyDeficitGoalKcal: 540,
+        avgDailyActualDeficit: 540,
+        startWeight: 70,
+        currentWeight: 69.8,
+      ),
+    );
+    expect(r.kind, DiagnosisKind.trackingMismatch);
+  });
+
+  test('weight up but body fat down -> bodyComp', () {
+    final r = runDiagnosis(
+      baseInput(
+        days: 30,
+        startWeight: 70,
+        currentWeight: 70.5,
+        startBodyFat: 22,
+        currentBodyFat: 20,
+      ),
+    );
+    expect(r.kind, DiagnosisKind.bodyComp);
+  });
+
+  test('actual ~= expected -> onTrack', () {
+    // Expected: 540*30/7700 ≈ 2.1 kg. Actual 1.8 kg -> 85%.
+    final r = runDiagnosis(
+      baseInput(
+        days: 30,
+        dailyDeficitGoalKcal: 540,
+        avgDailyActualDeficit: 540,
+        startWeight: 70,
+        currentWeight: 68.2,
+      ),
+    );
+    expect(r.kind, DiagnosisKind.onTrack);
+  });
+
+  test('settings diagnosis wins over trackingMismatch when both would match',
+      () {
+    // Low goal + bad actual — diagnosis prioritizes fixing the goal first.
+    final r = runDiagnosis(
+      baseInput(
+        days: 30,
+        dailyDeficitGoalKcal: 240,
+        avgDailyActualDeficit: 240,
+        startWeight: 70,
+        currentWeight: 69.9,
+      ),
+    );
+    expect(r.kind, DiagnosisKind.goalTooSmall);
+  });
+}

--- a/test/utils/weight_loss_calculator_test.dart
+++ b/test/utils/weight_loss_calculator_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tonton/utils/weight_loss_calculator.dart';
+
+void main() {
+  group('WeightLossCalculator.estimateTdee', () {
+    test('Mifflin-St Jeor: male 70kg/170cm/35yo activity 1.4 ~= 2350kcal', () {
+      final tdee = WeightLossCalculator.estimateTdee(
+        weightKg: 70,
+        heightCm: 170,
+        age: 35,
+        isMale: true,
+        activityFactor: 1.4,
+      );
+      // BMR = 10*70 + 6.25*170 - 5*35 + 5 = 700 + 1062.5 - 175 + 5 = 1592.5
+      // TDEE = 1592.5 * 1.4 = 2229.5
+      expect(tdee, closeTo(2229.5, 1.0));
+    });
+
+    test('female uses -161 offset', () {
+      final tdee = WeightLossCalculator.estimateTdee(
+        weightKg: 60,
+        heightCm: 160,
+        age: 30,
+        isMale: false,
+        activityFactor: 1.4,
+      );
+      // BMR = 10*60 + 6.25*160 - 5*30 - 161 = 600 + 1000 - 150 - 161 = 1289
+      // TDEE = 1289 * 1.4 = 1804.6
+      expect(tdee, closeTo(1804.6, 1.0));
+    });
+  });
+
+  group('WeightLossCalculator.requiredDailyDeficit', () {
+    test('70kg at 0.7%/week needs ~539 kcal/day deficit', () {
+      final deficit = WeightLossCalculator.requiredDailyDeficit(
+        weightKg: 70,
+        weeklyPercentLoss: 0.007,
+      );
+      // 70 * 0.007 * 7700 / 7 = 539
+      expect(deficit, closeTo(539, 1.0));
+    });
+
+    test('linear scaling with percent', () {
+      final d5 = WeightLossCalculator.requiredDailyDeficit(
+        weightKg: 70,
+        weeklyPercentLoss: 0.005,
+      );
+      final d10 = WeightLossCalculator.requiredDailyDeficit(
+        weightKg: 70,
+        weeklyPercentLoss: 0.010,
+      );
+      expect(d10 / d5, closeTo(2.0, 0.01));
+    });
+  });
+
+  group('WeightLossCalculator.expectedWeightLossKg', () {
+    test('7700 kcal deficit equals 1 kg loss', () {
+      final kg = WeightLossCalculator.expectedWeightLossKg(
+        cumulativeDeficitKcal: 7700,
+      );
+      expect(kg, closeTo(1.0, 0.001));
+    });
+
+    test('zero deficit => zero loss', () {
+      expect(
+        WeightLossCalculator.expectedWeightLossKg(cumulativeDeficitKcal: 0),
+        0,
+      );
+    });
+  });
+
+  group('WeightLossCalculator pace presets', () {
+    test('healthy pace range is 0.5% to 1.0% per week', () {
+      expect(WeightLossCalculator.minHealthyWeeklyPercent, 0.005);
+      expect(WeightLossCalculator.maxHealthyWeeklyPercent, 0.010);
+      expect(WeightLossCalculator.defaultWeeklyPercent, 0.007);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Three離脱ポイントの1つ「30日使っても体重が減らない → なぜか分からない」を構造的に説明するための診断MVP。慰めより先に**原因の見える化**と、原因に応じた次の一手を提示する。

## 機能
- **Home画面**: 現在の状態を6パターンで診断して1枚のカードで表示
  - `tooShort` (<7日): 水分変動の範囲です、あと◯日
  - `goalTooSmall`: 目標赤字が必要量に届いていない → Profileで目標ペース見直す CTA
  - `trackingMismatch` (設定OKだが実測不足、≥14日): 記録と実態のズレ疑い + チェックリスト（目分量 / 油・飲料 / 外食など）
  - `bodyComp`: 体重キープでも体脂肪↓ → 筋肉増加の可能性
  - `onTrack`: 順調です
- **Profile画面**: 減量ペース選択カード（ゆるめ0.5% / 標準0.7% / 攻め1.0%）。プリセット選択で必要日次赤字を自動反映
- **Savings画面**: 「期待 -◯kg / 実測 -◯kg」並置 + 達成率%
- **utils/weight_loss_calculator**: Mifflin-St Jeor TDEE + requiredDailyDeficit + expectedWeightLossKg

## 背景

ユーザー本人が30日使って体重が減っていない。聞き取りの結果、記録の歯抜けや摂取過多ではなく「-240kcal/日 × 30日 = -0.93kg」という設定値が日々の水分変動(±1-2kg)に埋もれるサイズだった。体重%ベースで健康的なペース(0.5〜1.0%/週)を基準に、必要な日次赤字を算出して診断する。

## Test plan
- [x] test/utils/weight_loss_calculator_test.dart 7/7 green
- [x] test/core/providers/diagnosis_logic_test.dart 6/6 green
- [x] flutter build ios --release --no-codesign clean (23.3MB)
- [ ] TestFlight: Home診断カードが本人の実データで「目標ペースを見直す」表示になるか
- [ ] Profile: 0.7%プリセット選択で日次赤字目標が 540 kcal 付近に更新されるか
- [ ] Savings: 期待 vs 実測 カードが表示されるか

🤖 Generated with [Claude Code](https://claude.com/claude-code)